### PR TITLE
Add new design for modal slideshow view

### DIFF
--- a/app/assets/stylesheets/blacklight_gallery/_slideshow.css.scss
+++ b/app/assets/stylesheets/blacklight_gallery/_slideshow.css.scss
@@ -4,51 +4,63 @@ $gray-dark: darkgray !default;
 #slideshow-modal {
   .modal-dialog {
     width: 100%;
+    margin: 1% auto;
+
+    .modal-content {
+      background-color: $gray-dark;
+    }
+
     .modal-header {
       border-bottom: none;
+
+      .close {
+        color: white;
+      }
+    }
+
+    .modal-body {
+      padding: 1%;
+      height: 90%;
     }
   }
 }
 
 #slideshow {
-  $slideshow-viewport-height: 400px;
-  .carousel-inner {
-    height: $slideshow-viewport-height;
+  height: 100%;
+
+  .slideshow-inner {
+    height: 100%;
+    overflow: hidden;
+
     .item {
       width: 100%;
       height: 100%;
-      .frame:before {
-          content: "";
-          display: inline-block;
-          height: 100%;
-          vertical-align: middle;
-      }
+      display: table;
+      vertical-align: middle;
+      position: relative;
+
       .frame {
-        width: 100%;
-        height: 100%;
-        display: inline-block;
+        margin: 0 auto;
+        display: table-cell;
         text-align: center;
         vertical-align: middle;
+        overflow: auto;
+
         img {
           display: inline-block;
           vertical-align: middle;
         }
       }
-
-      .carousel-caption {
-        display: none;
-      }
     }
   }
+
   .carousel-control {
-    height: $slideshow-viewport-height;
     background-image: none;
+    height: 100%;
+    width: 50px;
+
     .glyphicon {
-      background-color: $gray-light;
-      border-radius: 50%;
-      width: 50px;
-      height: 50px;
-      line-height: 50px;
+      color: $gray-light;
     }
   }
   .carousel-control.left .glyphicon  {
@@ -57,46 +69,71 @@ $gray-dark: darkgray !default;
   .carousel-control.right .glyphicon  {
     padding-left: 2px;
   }
-  .carousel-indicators {
-    position: relative;
-    bottom: 0;
-  }
-  .carousel-indicators li {
-    border: 1px solid rgba(100, 100, 100, .3);
-  }
-  .carousel-indicators li.active {
-    background-color: rgba(100, 100, 100, .3);
+
+  .caption {
+    font-size: 14px;
+    color: $gray-light;
+    margin: 10px auto;
+    min-width: 200px;
+    max-width: 50%;
   }
 
-  #slideshow-caption {
-    font-size: 18pt;
-    font-weight: 400;
-    font-color: $gray-dark;
-    text-align: center;
-    margin-top: 10px;
-  }
-
-  #slideshow-counter {
-    margin-top: 20px;
-    text-align: center;
-  }
-
-  .controls {
-    width: 250px;
-    margin-left: auto;
-    margin-right: auto;
-    margin-top: 10px;
-    text-align: center;
+  .counter {
+    // background-color: $gray-light;
+    border-radius: 12px;
     border: 1px solid $gray-light;
-    border-radius: 5px;
-    padding: 15px;
-    label {
-      margin-left: 10px;
-    }
-    .buttons {
-      font-size: 14pt;
-      a {
-        color: $gray-dark;
+    color: $gray-light;
+    font-size: 12px;
+    overflow: auto;
+    padding: 4px 10px;
+    text-align: center;
+  }
+}
+
+#documents {
+  margin: 0;
+
+  .info {
+    text-align: center;
+    margin-bottom: 15px;
+  }
+
+  h3 {
+    background-color: whitesmoke;
+    border-radius: 3px;
+    border: 1px solid #ddd;
+    display: inline-block;
+    font-size: 16px;
+    margin: 10px auto;
+    padding: 10px 15px;
+  }
+
+  .grid {
+    $square-thumb-size: 100px;
+
+    .document {
+      float: left;
+      margin-right: 20px;
+      margin-top: 0;
+      padding-top: 0;
+      border-bottom: 0;
+
+      .thumbnail {
+        border: 1px solid #999;
+        border-radius: 0;
+        min-width: $square-thumb-size;
+        min-height: $square-thumb-size;
+        overflow: hidden;
+        position: relative;
+        width: $square-thumb-size;
+
+        a > img {
+          position: absolute;
+          max-width: none;
+          max-height: none;
+          left: -50%;
+          top: -50%;
+        }
       }
     }
   }

--- a/app/views/catalog/_document_slideshow.html.erb
+++ b/app/views/catalog/_document_slideshow.html.erb
@@ -1,6 +1,9 @@
 <% # container for all documents in slideshow view -%>
 <div id="documents" class="row slideshow">
-  <h3><%= t(:'blacklight_gallery.catalog.document_slideshow.header') %></h3>
+  <div class="info">
+    <h3><%= t(:'blacklight_gallery.catalog.document_slideshow.header') %></h3>
+  </div>
+
   <div class="grid">
     <%= render collection: documents, as: :document, partial: 'grid_slideshow' %>
   </div>

--- a/app/views/catalog/_grid_slideshow.html.erb
+++ b/app/views/catalog/_grid_slideshow.html.erb
@@ -1,4 +1,4 @@
-<div class="document col-xs-6 col-md-3">
+<div class="document">
   <div class="thumbnail">
     <%= link_to '#', data: { :'slide-to' => document_counter, toggle: "modal", target: "#slideshow-modal" } do %>
       <%= image_tag thumbnail_url(document) %>

--- a/app/views/catalog/_index_slideshow.html.erb
+++ b/app/views/catalog/_index_slideshow.html.erb
@@ -1,8 +1,11 @@
 <div class="item<%= ' active' if document_counter == 0 %>">
   <div class="frame">
-    <%= image_tag thumbnail_url(document) %>
-  </div>
-  <div class="carousel-caption">
-    <%= render_document_index_label document, label: document_show_link_field(document) %>
+      <%= image_tag thumbnail_url(document) %>
+      <div class="caption">
+        <%= render_document_index_label document, label: document_show_link_field(document) %>
+      </div>
+      <span class="counter">
+        <%= t :'blacklight_gallery.catalog.modal_slideshow.counter', counter: document_counter + 1, count: count %>
+      </span>
   </div>
 </div>

--- a/app/views/catalog/_slideshow.html.erb
+++ b/app/views/catalog/_slideshow.html.erb
@@ -1,39 +1,16 @@
-  <div id="slideshow" class="carousel slide">
+  <div id="slideshow" class="">
     <!-- Wrapper for slides -->
-    <div class="carousel-inner">
-      <%= render collection: documents, as: :document, partial: 'index_slideshow' %>
+    <div class="slideshow-inner">
+      <%= render collection: documents, as: :document, partial: 'index_slideshow', locals: {count: documents.count} %>
     </div>
-
-    <!-- Indicators -->
-    <ol class="carousel-indicators">
-      <% documents.each_with_index do |_, i| %>
-        <li data-target="#slideshow" data-slide-to="<%= i %>"<%=' class="active"'.html_safe if i == 0 %>></li>
-      <% end %>
-    </ol>
 
     <!-- Controls -->
-    <a class="left carousel-control" href="#slideshow" data-slide="prev">
+    <a class="left carousel-control prev" href="#slideshow" data-slide="prev">
       <span class="glyphicon glyphicon-chevron-left"></span>
     </a>
-    <a class="right carousel-control" href="#slideshow" data-slide="next">
+    <a class="right carousel-control next" href="#slideshow" data-slide="next">
       <span class="glyphicon glyphicon-chevron-right"></span>
     </a>
-    <div id="slideshow-caption"><%# javascript puts the caption here %></div>
-    <div id="slideshow-counter">
-      <span id="current-slideshow-index"></span> of <%= documents.count %>
-    </div>
-    <div class="controls">
-      <div class="buttons">
-        <a href="#slideshow" data-slide="prev"><span class="glyphicon glyphicon-step-backward"></span></a>
-        <a href="#slideshow" data-state="pause"><span class="glyphicon glyphicon-pause"></span></a>
-        <a href="#slideshow" data-state="play"><span class="glyphicon glyphicon-play"></span></a>
-        <a href="#slideshow" data-slide="next"><span class="glyphicon glyphicon-step-forward"></span></a>
-      </div>
-      <div>
-        <label><input type="radio" name="speed" data-velocity value="6000"> Slow</label>
-        <label><input type="radio" name="speed" data-velocity value="3000" checked> Medium</label>
-        <label><input type="radio" name="speed" data-velocity value="2000"> Fast</label>
-      </div>
-    </div>
+
   </div>
 

--- a/app/views/catalog/_slideshow_modal.html.erb
+++ b/app/views/catalog/_slideshow_modal.html.erb
@@ -1,9 +1,9 @@
   <!-- Modal -->
   <div class="modal fade" id="slideshow-modal" tabindex="-1" role="dialog" aria-labelledby="slideshow-modal-label" aria-hidden="true">
-    <div class="modal-dialog">
+    <div class="modal-dialog col-md-10">
       <div class="modal-content">
         <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-hidden="true">Close <span class="glyphicon glyphicon-remove-circle"></span></button>
+          <button type="button" class="close" data-dismiss="modal" aria-hidden="true"><span class="glyphicon glyphicon-remove"></span></button>
         </div>
         <div class="modal-body">
           <%= yield %>

--- a/config/locales/blacklight-gallery.en.yml
+++ b/config/locales/blacklight-gallery.en.yml
@@ -7,4 +7,6 @@ en:
   blacklight_gallery:
     catalog:
       document_slideshow:
-        header: "Click an image to start the slideshow"
+        header: "Select an image to start the slideshow"
+      modal_slideshow:
+        counter: "%{counter} of %{count}"

--- a/lib/generators/blacklight_gallery/templates/blacklight_gallery.js
+++ b/lib/generators/blacklight_gallery/templates/blacklight_gallery.js
@@ -1,2 +1,1 @@
-//= require bootstrap/carousel
-
+//= require blacklight_gallery/slideshow

--- a/spec/features/slideshow_spec.rb
+++ b/spec/features/slideshow_spec.rb
@@ -8,8 +8,9 @@ describe "Slideshow", :js do
     within ".view-type" do
       click_link "Slideshow"
     end
-    find('.grid [data-slide-to="0"]').click
+
+    find('.grid [data-slide-to="0"]').trigger('click')
     expect(page).to have_selector '#slideshow', visible: true
   end
-  
+
 end

--- a/spec/views/catalog/_document_slideshow.html.erb_spec.rb
+++ b/spec/views/catalog/_document_slideshow.html.erb_spec.rb
@@ -15,11 +15,6 @@ describe "catalog/_document_slideshow.html.erb" do
     expect(rendered).to have_selector '#slideshow-modal'
     expect(rendered).to have_selector '[data-slide="prev"]'
     expect(rendered).to have_selector '[data-slide="next"]'
-    expect(rendered).to have_selector '[data-state="play"]'
-    expect(rendered).to have_selector '[data-state="pause"]'
-    expect(rendered).to have_selector '[data-velocity][value="2000"]'
-    expect(rendered).to have_selector '[data-velocity][value="3000"]'
-    expect(rendered).to have_selector '[data-velocity][value="6000"]'
     expect(rendered).to have_selector '[data-slide-to="0"][data-toggle="modal"][data-target="#slideshow-modal"]'
   end
 end


### PR DESCRIPTION
Modal slideshow view updated with new design (sul-dlss/spotlight#554)- 
- Replaced bootstrap-carousel extension with custom functions 
- Changed modal to full-screen with centered image
- Removed indicators and play/pause related controls

![modal-slideshow](https://f.cloud.github.com/assets/302258/2484371/960f1502-b10c-11e3-9c82-86b60733c365.png)

To-do: On image hover, move caption as a slide-in with configurable text truncation
