### PR TITLE
Prevent SolrDocument#fetch from throwing an error if the document…

### DIFF
--- a/app/models/concerns/blacklight/gallery/openseadragon_solr_document.rb
+++ b/app/models/concerns/blacklight/gallery/openseadragon_solr_document.rb
@@ -1,7 +1,7 @@
 module Blacklight::Gallery::OpenseadragonSolrDocument
-  def to_openseadragon view_config = nil
-    if view_config and view_config.tile_source_field
-      Array(fetch(view_config.tile_source_field))
-    end
+  def to_openseadragon(view_config = nil)
+    return unless view_config.try(:tile_source_field) &&
+                  fetch(view_config.tile_source_field, nil)
+    Array(fetch(view_config.tile_source_field))
   end
 end

--- a/blacklight-gallery.gemspec
+++ b/blacklight-gallery.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency "rspec-rails", "~> 3.1"
   spec.add_development_dependency "rspec-its"
   spec.add_development_dependency "rspec-activemodel-mocks"

--- a/spec/models/concerns/openseadragon_solr_document_spec.rb
+++ b/spec/models/concerns/openseadragon_solr_document_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Blacklight::Gallery::OpenseadragonSolrDocument do
+  subject { SolrDocument.new(fields).to_openseadragon(view_config) }
+
+  context 'when configured for the view' do
+    let(:fields) { { some_field: 'data' } }
+    let(:view_config) { double('ViewConfig', tile_source_field: :some_field) }
+    it 'returns the data from the document as an array' do
+      expect(subject).to eq ['data']
+    end
+  end
+
+  context 'when not configured for the view' do
+    let(:fields) { { some_field: 'data' } }
+    let(:view_config) { double('ViewConfig') }
+    it 'returns nil' do
+      expect(subject).to be_nil
+    end
+  end
+
+  context 'when the document has the field' do
+    let(:fields) { { some_field: 'data' } }
+    let(:view_config) { double('ViewConfig', tile_source_field: :some_field) }
+    it 'returns the data from the document as an array' do
+      expect(subject).to eq ['data']
+    end
+  end
+
+  context 'when the document does not have the field' do
+    let(:fields) { { some_other_field: 'data' } }
+    let(:view_config) { double('ViewConfig', tile_source_field: :some_field) }
+    it 'returns the data from the document as an array' do
+      expect(subject).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
… does not have the field.