### PR TITLE
A recent Safari update broke the gallery view. This fixes it.

### DIFF
--- a/app/assets/stylesheets/blacklight_gallery/_gallery.scss
+++ b/app/assets/stylesheets/blacklight_gallery/_gallery.scss
@@ -10,6 +10,7 @@
   display: -webkit-flex;
   display: flex;
   flex-flow: row wrap;
+  -webkit-flex-wrap: wrap;
 
 
   .document {
@@ -17,12 +18,12 @@
 
     -webkit-box-flex: 1;
     -moz-box-flex: 1;
-    -webkit-flex: 1;
     -ms-flex: 1;
     flex: 1;
 
     min-width: 250px;
     min-height: 250px;
+    -webkit-flex: 1 0 250px;
   }
 
   .index_title {


### PR DESCRIPTION
On the latest iPhone and Mac Safari, the gallery view was broken as the
properties for flex that browser uses changed. To see an example of this
broken view from a random Hydra Head online (fixed it in mine):

In your iPhone or Mac Safari browser:
* Go to https://scholarsphere.psu.edu/ and do a blank search.

* Switch to the gallery view.

* See how the objects do not wrap properly but rather go off the screen.

Part of this fix (setting the webkit-flex base value to the min-width
value) comes from an existing known issue report and was modified to
the CSS properties Safari prefers now:
https://github.com/philipwalton/flexbugs#11-min-and-max-size-declarations-are-ignored-when-wrapping-flex-items