### PR TITLE
Adjust col-xs for Bootstrap 4

### DIFF
--- a/app/views/catalog/_index_gallery.html.erb
+++ b/app/views/catalog/_index_gallery.html.erb
@@ -1,4 +1,4 @@
-<div class="document col-xs-6 col-md-3">
+<div class="document col-6 col-md-3">
   <div class="thumbnail">
     <%= render_thumbnail_tag(document, {}, :counter => document_counter_with_offset(document_counter)) %>
     <div class="caption">

--- a/app/views/catalog/_index_masonry.html.erb
+++ b/app/views/catalog/_index_masonry.html.erb
@@ -1,4 +1,4 @@
-<div class="masonry document col-xs-6 col-md-3">
+<div class="masonry document col-6 col-md-3">
   <div class="thumbnail">
     <%= render_thumbnail_tag(document, {}, :counter => document_counter_with_offset(document_counter)) %>
     <div class="caption">


### PR DESCRIPTION
https://getbootstrap.com/docs/4.1/layout/grid/#grid-options
<img width="864" alt="Screen Shot 2019-04-17 at 12 09 15 PM" src="https://user-images.githubusercontent.com/751697/56314397-cd641900-6109-11e9-8a1d-0db3565844c3.png">

https://stackoverflow.com/questions/41794746/col-xs-not-working-in-bootstrap-4
>col-xs-* have been dropped in Bootstrap 4 in favor of col-*.
>
>Replace col-xs-12 with col-12 and it will work as expected.
>
>Also note col-xs-offset-{n} were replaced by offset-{n} in v4.

---

+ modified:   app/views/catalog/_index_gallery.html.erb
+ modified:   app/views/catalog/_index_masonry.html.erb