### PR TITLE
Use the new bootstrap 4 thumbnail classes

### DIFF
--- a/app/assets/stylesheets/blacklight_gallery/_gallery.scss
+++ b/app/assets/stylesheets/blacklight_gallery/_gallery.scss
@@ -1,5 +1,5 @@
 .view-icon-gallery {
-  &:before { content: "\e011"; } 
+  &:before { content: "\e011"; }
 }
 
 .gallery {
@@ -26,8 +26,12 @@
     -webkit-flex: 1 0 250px;
   }
 
+  .caption {
+    @extend .mt-2;
+  }
+
   .index_title {
-    width: 100%;
+    @extend .h6;
   }
 
   .document-counter {
@@ -38,7 +42,7 @@
     clear: left;
   }
 
-  .document-metadata { 
+  .document-metadata {
     dt, dd {
       float: none;
       width: auto;

--- a/app/assets/stylesheets/blacklight_gallery/_slideshow.scss
+++ b/app/assets/stylesheets/blacklight_gallery/_slideshow.scss
@@ -121,6 +121,7 @@ $gray-dark: darkgray !default;
       margin-top: 0;
       padding-top: 0;
       border-bottom: 0;
+      margin-bottom: 1rem;
 
       .thumbnail {
         border: 1px solid #999;

--- a/app/views/catalog/_document_slideshow.html.erb
+++ b/app/views/catalog/_document_slideshow.html.erb
@@ -1,6 +1,6 @@
 <% # container for all documents in slideshow view -%>
 <div id="documents" class="row slideshow-documents">
-  <div class="info">
+  <div class="info w-100">
     <h3><%= t(:'blacklight_gallery.catalog.document_slideshow.header') %></h3>
   </div>
 

--- a/app/views/catalog/_grid_slideshow.html.erb
+++ b/app/views/catalog/_grid_slideshow.html.erb
@@ -2,7 +2,7 @@
   <div class="thumbnail">
     <%= link_to '#', data: { :'slide-to' => document_counter, toggle: "modal", target: "#slideshow-modal" } do %>
       <% if thumbnail_url(document) %>
-          <%= image_tag thumbnail_url(document) %>
+          <%= image_tag thumbnail_url(document), class: 'img-thumbnail' %>
         <% else %>
           <%= t('.missing_image', scope: [:blacklight_gallery]) %>
         <% end %>

--- a/app/views/catalog/_index_gallery.html.erb
+++ b/app/views/catalog/_index_gallery.html.erb
@@ -1,6 +1,6 @@
 <div class="document col-6 col-md-3">
   <div class="thumbnail">
-    <%= render_thumbnail_tag(document, {}, :counter => document_counter_with_offset(document_counter)) %>
+    <%= render_thumbnail_tag(document, { class: 'img-thumbnail' }, :counter => document_counter_with_offset(document_counter)) %>
     <div class="caption">
       <%= render_document_partials document, blacklight_config.view_config(:gallery).partials, :document_counter => document_counter %>
     </div>

--- a/app/views/catalog/_index_masonry.html.erb
+++ b/app/views/catalog/_index_masonry.html.erb
@@ -1,6 +1,6 @@
 <div class="masonry document col-6 col-md-3">
   <div class="thumbnail">
-    <%= render_thumbnail_tag(document, {}, :counter => document_counter_with_offset(document_counter)) %>
+    <%= render_thumbnail_tag(document, { class: 'img-thumbnail' }, counter: document_counter_with_offset(document_counter)) %>
     <div class="caption">
       <%= render_document_partials document, blacklight_config.view_config(:masonry).partials, :document_counter => document_counter %>
     </div>

--- a/spec/views/catalog/_index_gallery.html.erb_spec.rb
+++ b/spec/views/catalog/_index_gallery.html.erb_spec.rb
@@ -13,7 +13,7 @@ describe "catalog/_index_gallery.html.erb", :type => :view do
   end
 
   it "should have thumbnail and caption" do
-    expect(view).to receive(:render_thumbnail_tag).with(document, {}, hash_including(:counter)).and_return('Thumbnail')
+    expect(view).to receive(:render_thumbnail_tag).with(document, { class: 'img-thumbnail' }, hash_including(:counter)).and_return('Thumbnail')
     expect(view).to receive(:render_document_partials).with(document, ['a', 'b'], document_counter: 3).and_return('Z')
     render
     expect(rendered).to have_selector '.thumbnail', text: 'Thumbnail'


### PR DESCRIPTION
Fixes #62 

![Screen Shot 2019-11-12 at 16 23 58](https://user-images.githubusercontent.com/111218/68721946-e1b9a880-0568-11ea-8643-b9b84b1dcb2f.png)
