### PR TITLE
Use modal-xl instead of a column definition for the slideshow modal.

### DIFF
--- a/app/views/catalog/_slideshow_modal.html.erb
+++ b/app/views/catalog/_slideshow_modal.html.erb
@@ -1,6 +1,6 @@
   <!-- Modal -->
   <div class="slideshow-modal modal fade" id="slideshow-modal" tabindex="-1" role="dialog" aria-labelledby="slideshow-modal-label" aria-hidden="true">
-    <div class="modal-dialog col-md-10">
+    <div class="modal-dialog modal-xl">
       <div class="modal-content">
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal" aria-hidden="true">


### PR DESCRIPTION
Closes projectblacklight/spotlight#2325

## Before
<img width="1317" alt="before" src="https://user-images.githubusercontent.com/96776/70485185-11de6380-1aa3-11ea-9463-6a459988540e.png">

## After
<img width="1312" alt="after" src="https://user-images.githubusercontent.com/96776/70485186-11de6380-1aa3-11ea-9b84-1c8a41aa097d.png">

Note: the images/config here aren't larger than 400px, but larger images will fill the space.