### PR TITLE
Remove document min-width to rely on bootstrap column min-widths.

### DIFF
--- a/app/assets/stylesheets/blacklight_gallery/_gallery.scss
+++ b/app/assets/stylesheets/blacklight_gallery/_gallery.scss
@@ -17,7 +17,6 @@
     -ms-flex: 1;
     flex: 1;
 
-    min-width: 250px;
     min-height: 250px;
     -webkit-flex: 1 0 250px;
   }


### PR DESCRIPTION
Closes sul-dlss/exhibits#1617

## Before
![gallery-responsive-before](https://user-images.githubusercontent.com/96776/74007805-11900680-4934-11ea-9c67-95593cb9fad8.gif)

## After
![gallery-responsive-after](https://user-images.githubusercontent.com/96776/74007790-063cdb00-4934-11ea-8a6e-6980bdf1daac.gif)
