### PR TITLE
Move overriding of Bootstrap thumbnail stying from the thumbnail …

### DIFF
--- a/app/assets/stylesheets/blacklight_gallery/_masonry.scss
+++ b/app/assets/stylesheets/blacklight_gallery/_masonry.scss
@@ -6,11 +6,11 @@
     background-color: $gray-300;
     min-height: 70px;
 
-    .thumbnail {
-      border: 0;
+    .img-thumbnail {
+      border-radius: 0;
       padding: 0;
-      margin-bottom: 0;
     }
+
     .caption {
       &:first-child { display: block; } // To display captions when there is no image
       a {


### PR DESCRIPTION
…class to the img-thumbnail class.

## Before
<img width="698" alt="masonry-before" src="https://user-images.githubusercontent.com/96776/74054252-8a25b000-4992-11ea-9217-1c05979b2980.png">

## After
<img width="700" alt="masonry-after" src="https://user-images.githubusercontent.com/96776/74054255-8e51cd80-4992-11ea-8b08-7a17c1a1434d.png">
