### PR TITLE
Allow bootstrap column padding to be used on dt/dd so that the …

### DIFF
--- a/app/assets/stylesheets/blacklight_gallery/_gallery.scss
+++ b/app/assets/stylesheets/blacklight_gallery/_gallery.scss
@@ -45,7 +45,6 @@
       clear: none;
       text-align: left;
       margin: 0;
-      padding: 0;
     }
 
   }


### PR DESCRIPTION
…metadata is aligned properly.

Part of sul-dlss/exhibits#1605

## Before
<img width="855" alt="gallery-md-before" src="https://user-images.githubusercontent.com/96776/74060361-a7607b80-499e-11ea-8eb3-b80a1176a3fe.png">


## After
<img width="834" alt="gallery-md-after" src="https://user-images.githubusercontent.com/96776/74060258-7122fc00-499e-11ea-8b8d-05c4609ff3cb.png">
