### PR TITLE
Remove the alt text from the thumbnail

### DIFF
--- a/app/views/catalog/_index_gallery.html.erb
+++ b/app/views/catalog/_index_gallery.html.erb
@@ -1,6 +1,6 @@
 <div class="document col-6 col-md-4">
   <div class="thumbnail">
-    <%= render_thumbnail_tag(document, { class: 'img-thumbnail' }, :counter => document_counter_with_offset(document_counter)) %>
+    <%= render_thumbnail_tag(document, { class: 'img-thumbnail', alt: '' }, :counter => document_counter_with_offset(document_counter)) %>
     <div class="caption">
       <%= render_document_partials document, blacklight_config.view_config(:gallery).partials, :document_counter => document_counter %>
     </div>

--- a/spec/views/catalog/_index_gallery.html.erb_spec.rb
+++ b/spec/views/catalog/_index_gallery.html.erb_spec.rb
@@ -13,7 +13,7 @@ describe "catalog/_index_gallery.html.erb", :type => :view do
   end
 
   it "should have thumbnail and caption" do
-    expect(view).to receive(:render_thumbnail_tag).with(document, { class: 'img-thumbnail' }, hash_including(:counter)).and_return('Thumbnail')
+    expect(view).to receive(:render_thumbnail_tag).with(document, { class: 'img-thumbnail', alt: '' }, hash_including(:counter)).and_return('Thumbnail')
     expect(view).to receive(:render_document_partials).with(document, ['a', 'b'], document_counter: 3).and_return('Z')
     render
     expect(rendered).to have_selector '.thumbnail', text: 'Thumbnail'


### PR DESCRIPTION
At least by default, the caption will also include a link to the document with the title.

Part of https://github.com/sul-dlss/exhibits/issues/1585