### PR TITLE
Remove default autoPlay of slideshow and add buttons to allow user to…

### DIFF
--- a/app/assets/images/blacklight/pause_slideshow.svg
+++ b/app/assets/images/blacklight/pause_slideshow.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 14H9V8h2v8zm4 0h-2V8h2v8z"></path></svg

--- a/app/assets/images/blacklight/start_slideshow.svg
+++ b/app/assets/images/blacklight/start_slideshow.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z"></path></svg>

--- a/app/assets/javascripts/blacklight_gallery/slideshow.js
+++ b/app/assets/javascripts/blacklight_gallery/slideshow.js
@@ -72,12 +72,16 @@
       var $img = this.$element.find('.frame img'),
           _this = this;
 
-      // pause slideshow on image mouseenter event
-      $img.on('mouseenter', function() {  _this.pause(); });
+      $(document).on('click', '[data-behavior="pause-slideshow"]', function(e) {
+        e.preventDefault();
 
-      // play slideshow on image mouseleave event
-      $img.on('mouseleave', function() {
-        if (_this.options.autoPlay) _this.play();
+        _this.pause();
+      });
+
+      $(document).on('click', '[data-behavior="start-slideshow"]', function(e) {
+        e.preventDefault();
+
+        _this.play();
       });
 
       $(document).on('click', '[data-slide], [data-slide-to]', function(e) {
@@ -99,7 +103,7 @@
 
 
   Slideshow.DEFAULTS = {
-    autoPlay: true,
+    autoPlay: false,
     interval: 5000 // in milliseconds
   }
 

--- a/app/assets/stylesheets/blacklight_gallery/_slideshow.scss
+++ b/app/assets/stylesheets/blacklight_gallery/_slideshow.scss
@@ -93,6 +93,12 @@ $gray-dark: #343a40 !default;
     padding: 4px 10px;
     text-align: center;
   }
+
+  .controls {
+    svg {
+      fill: $gray-light;
+    }
+  }
 }
 
 .slideshow-documents {

--- a/app/views/catalog/_document_slideshow.html.erb
+++ b/app/views/catalog/_document_slideshow.html.erb
@@ -1,9 +1,5 @@
 <% # container for all documents in slideshow view -%>
 <div id="documents" class="row slideshow-documents">
-  <div class="info w-100">
-    <h3><%= t(:'blacklight_gallery.catalog.document_slideshow.header') %></h3>
-  </div>
-
   <div class="grid">
     <%= render collection: documents, as: :document, partial: 'grid_slideshow' %>
   </div>

--- a/app/views/catalog/_slideshow.html.erb
+++ b/app/views/catalog/_slideshow.html.erb
@@ -12,4 +12,12 @@
       <%= blacklight_icon 'chevron_right' %>
     </a>
 
+    <div class="controls text-center">
+      <button class="btn btn-sm btn-link" data-behavior="pause-slideshow" aria-label="<%= t('blacklight_gallery.catalog.slideshow.pause') %>">
+        <%= blacklight_icon 'pause_slideshow' %>
+      </button>
+      <button class="btn btn-sm btn-link" data-behavior="start-slideshow" aria-label="<%= t('blacklight_gallery.catalog.slideshow.start') %>">
+        <%= blacklight_icon 'start_slideshow' %>
+      </button>
+    </div>
   </div>

--- a/config/locales/blacklight-gallery.ar.yml
+++ b/config/locales/blacklight-gallery.ar.yml
@@ -9,7 +9,8 @@ ar:
     catalog:
       grid_slideshow:
         missing_image: "صورة غير موجودة"
-      document_slideshow:
-        header: "حدد صورة لبدء العرض المتتابع"
       modal_slideshow:
         counter: "%{counter} من %{count}"
+      slideshow:
+        pause: "وقفة عرض الشرائح"
+        start: "بدء عرض الشرائح"

--- a/config/locales/blacklight-gallery.en.yml
+++ b/config/locales/blacklight-gallery.en.yml
@@ -9,7 +9,8 @@ en:
     catalog:
       grid_slideshow:
         missing_image: 'Missing'
-      document_slideshow:
-        header: "Select an image to start the slideshow"
       modal_slideshow:
         counter: "%{counter} of %{count}"
+      slideshow:
+        pause: Pause slideshow
+        start: Start slideshow

--- a/config/locales/blacklight-gallery.es.yml
+++ b/config/locales/blacklight-gallery.es.yml
@@ -9,7 +9,8 @@ es:
     catalog:
       grid_slideshow:
         missing_image: No hay nada
-      document_slideshow:
-        header: Selecione una imagen para empezar
       modal_slideshow:
         counter: "%{counter} de %{count}"
+      slideshow:
+        pause: Pausa la Diapositivas
+        start: Empezar la Diapositivas

--- a/config/locales/blacklight-gallery.fr.yml
+++ b/config/locales/blacklight-gallery.fr.yml
@@ -9,7 +9,8 @@ fr:
     catalog:
       grid_slideshow:
         missing_image: 'Image manquante'
-      document_slideshow:
-        header: "Sélectionnez une image pour lancer le diaporama"
       modal_slideshow:
         counter: "%{counter} de %{count}"
+      slideshow:
+        pause: Suspendre le diaporama
+        start: Lancer le diaporama

--- a/config/locales/blacklight-gallery.it.yml
+++ b/config/locales/blacklight-gallery.it.yml
@@ -9,7 +9,8 @@ it:
     catalog:
       grid_slideshow:
         missing_image: 'Mancante'
-      document_slideshow:
-        header: "Seleziona un immagine per l'avvio del slideshow"
       modal_slideshow:
         counter: "%{counter} di %{count}"
+      slideshow:
+        pause: Pausa del slideshow
+        start: Avvia del slideshow

--- a/config/locales/blacklight-gallery.pt-BR.yml
+++ b/config/locales/blacklight-gallery.pt-BR.yml
@@ -13,3 +13,6 @@ pt-BR:
         header: "Selecione uma imagem para iniciar a apresentação de slides"
       modal_slideshow:
         counter: "%{counter} de %{count}"
+      slideshow:
+        pause: Pausar a apresentação de slides
+        start: Iniciar a apresentação de slides

--- a/config/locales/blacklight-gallery.zh.yml
+++ b/config/locales/blacklight-gallery.zh.yml
@@ -9,7 +9,8 @@ zh:
     catalog:
       grid_slideshow:
         missing_image: '图片缺失'
-      document_slideshow:
-        header: '选择图片启动幻灯展示'
       modal_slideshow:
         counter: "%{counter} of %{count}"
+      slideshow:
+        pause: 暂停幻灯片展示
+        start: 启动幻灯片展示

--- a/lib/blacklight/gallery/engine.rb
+++ b/lib/blacklight/gallery/engine.rb
@@ -4,7 +4,6 @@ module Blacklight
   module Gallery
     class Engine < Rails::Engine
       require 'openseadragon'
-    
     end
   end
 end


### PR DESCRIPTION
… start/pause.

Closes sul-dlss/exhibits#1775

The rationale is that a user who wants a slideshow can start one once the modal is open, and the current behavior of pause/play with mouse only events isn't accessible to non-mouse users.

<img width="1186" alt="Screen Shot 2020-03-03 at 12 00 23 PM" src="https://user-images.githubusercontent.com/96776/75814699-0d92b100-5d47-11ea-9304-ff47ee26a3f2.png">
