### PR TITLE
Link image and title in slideshow modal out to document

### DIFF
--- a/app/assets/stylesheets/blacklight_gallery/_slideshow.scss
+++ b/app/assets/stylesheets/blacklight_gallery/_slideshow.scss
@@ -85,10 +85,16 @@ $gray-dark: #343a40 !default;
 
   .caption {
     font-size: 1rem;
-    color: $gray-light;
     margin: 10px auto;
     min-width: 200px;
     max-width: 50%;
+    a {
+      color: $gray-light;
+      text-decoration: underline;
+      &:hover, &:focus {
+        color: #ffffff;
+      }
+    }
   }
 
   .counter {

--- a/app/components/blacklight/gallery/slideshow_component.html.erb
+++ b/app/components/blacklight/gallery/slideshow_component.html.erb
@@ -2,7 +2,7 @@
   <div class="frame">
       <%= slideshow_tag %>
       <div class="caption">
-        <%= presenter.heading %>
+        <%= presenter.view_context.link_to_document(presenter.document, presenter.heading, counter: @counter) %>
       </div>
 
       <span class="counter">

--- a/app/components/blacklight/gallery/slideshow_component.html.erb
+++ b/app/components/blacklight/gallery/slideshow_component.html.erb
@@ -2,7 +2,7 @@
   <div class="frame">
       <%= slideshow_tag %>
       <div class="caption">
-        <%= presenter.view_context.link_to_document(presenter.document, presenter.heading, counter: @counter) %>
+        <%= helpers.link_to_document(presenter.document, presenter.heading, counter: @counter) %>
       </div>
 
       <span class="counter">

--- a/app/components/blacklight/gallery/slideshow_component.rb
+++ b/app/components/blacklight/gallery/slideshow_component.rb
@@ -20,10 +20,11 @@ module Blacklight
           method_name = view_config.slideshow_method
           @view_context.send(method_name, @document, image_options)
         elsif view_config.slideshow_field
-          url = slideshow_image_url
-          image_tag url, image_options if url.present?
+          return if slideshow_image_url.blank?
+          image = image_tag slideshow_image_url, image_options
+          helpers.link_to_document(@document, image)
         elsif presenter.thumbnail.exists?
-          presenter.thumbnail.thumbnail_tag(image_options, url_options)
+          presenter.thumbnail.thumbnail_tag(image_options)
         end
       end
 

--- a/app/components/blacklight/gallery/slideshow_component.rb
+++ b/app/components/blacklight/gallery/slideshow_component.rb
@@ -21,10 +21,9 @@ module Blacklight
           @view_context.send(method_name, @document, image_options)
         elsif view_config.slideshow_field
           url = slideshow_image_url
-
           image_tag url, image_options if url.present?
         elsif presenter.thumbnail.exists?
-          presenter.thumbnail.thumbnail_tag(image_options, url_options.reverse_merge(suppress_link: true))
+          presenter.thumbnail.thumbnail_tag(image_options, url_options)
         end
       end
 

--- a/spec/components/blacklight/gallery/slideshow_component_spec.rb
+++ b/spec/components/blacklight/gallery/slideshow_component_spec.rb
@@ -15,20 +15,29 @@ RSpec.describe Blacklight::Gallery::SlideshowComponent, type: :component do
     Capybara::Node::Simple.new(render)
   end
 
-  let(:blacklight_config) { Blacklight::Configuration.new }
+  let(:document) do
+    SolrDocument.new(
+      id: 'x',
+    )
+  end
+
   let(:presenter) { Blacklight::IndexPresenter.new(document, view_context, blacklight_config) }
 
   before do
+    allow(view_context).to receive(:current_search_session).and_return(nil)
+    allow(view_context).to receive(:search_session).and_return({})
     allow(view_context).to receive(:blacklight_config).and_return(blacklight_config)
   end
 
   describe '#slideshow_tag' do
     subject { rendered }
 
-    let(:document) { SolrDocument.new({}) }
-
     context 'with a slideshow method' do
-      let(:blacklight_config) { Blacklight::Configuration.new.tap { |config| config.index.slideshow_method = :xyz } }
+      let(:blacklight_config) { Blacklight::Configuration.new.tap { 
+        |config| config.index.slideshow_method = :xyz
+        config.track_search_session = false
+        # binding.pry
+      } }
 
       it 'calls the provided slideshow method' do
         expect(view_context).to receive_messages(xyz: 'some-slideshow')
@@ -42,25 +51,34 @@ RSpec.describe Blacklight::Gallery::SlideshowComponent, type: :component do
     end
 
     context 'with a field' do
-      let(:blacklight_config) { Blacklight::Configuration.new.tap { |config| config.index.slideshow_field = :xyz } }
-      let(:document) { SolrDocument.new({ xyz: 'http://example.com/some.jpg' }) }
+      let(:blacklight_config) { Blacklight::Configuration.new.tap { |config| 
+        config.index.slideshow_field = :xyz 
+        config.track_search_session = false
+      } }
+      let(:document) { SolrDocument.new({ xyz: 'http://example.com/some.jpg', id: 'x' }) }
 
       it { is_expected.to have_selector 'img[src="http://example.com/some.jpg"]' }
 
       context 'without data in the field' do
-        let(:document) { SolrDocument.new({}) }
+        let(:document) { SolrDocument.new({id: 'x'}) }
 
         it { is_expected.not_to have_selector 'img' }
       end
     end
 
-    context 'with nothing configured' do
+    context 'with no view_config' do
+      let(:blacklight_config) { Blacklight::Configuration.new.tap { |config| 
+        config.track_search_session = false
+      } }
       it { is_expected.not_to have_selector 'img' }
     end
 
     context 'falling back to a thumbnail' do
-      let(:blacklight_config) { Blacklight::Configuration.new.tap { |config| config.index.thumbnail_field = :xyz } }
-      let(:document) { SolrDocument.new({ xyz: 'http://example.com/thumb.jpg' }) }
+      let(:blacklight_config) { Blacklight::Configuration.new.tap { |config| 
+        config.index.thumbnail_field = :xyz 
+        config.track_search_session = false
+        } }
+      let(:document) { SolrDocument.new({ xyz: 'http://example.com/thumb.jpg', id: 'x' }) }
 
       it { is_expected.to have_selector 'img[src="http://example.com/thumb.jpg"]' }
     end

--- a/spec/components/blacklight/gallery/slideshow_component_spec.rb
+++ b/spec/components/blacklight/gallery/slideshow_component_spec.rb
@@ -33,11 +33,12 @@ RSpec.describe Blacklight::Gallery::SlideshowComponent, type: :component do
     subject { rendered }
 
     context 'with a slideshow method' do
-      let(:blacklight_config) { Blacklight::Configuration.new.tap { 
-        |config| config.index.slideshow_method = :xyz
-        config.track_search_session = false
-        # binding.pry
-      } }
+      let(:blacklight_config) do
+        Blacklight::Configuration.new.tap do |config|
+          config.index.slideshow_method = :xyz
+          config.track_search_session = false
+        end
+      end
 
       it 'calls the provided slideshow method' do
         expect(view_context).to receive_messages(xyz: 'some-slideshow')
@@ -50,11 +51,13 @@ RSpec.describe Blacklight::Gallery::SlideshowComponent, type: :component do
       end
     end
 
-    context 'with a field' do
-      let(:blacklight_config) { Blacklight::Configuration.new.tap { |config| 
-        config.index.slideshow_field = :xyz 
-        config.track_search_session = false
-      } }
+    context 'with a slideshow field' do
+      let(:blacklight_config) do
+        Blacklight::Configuration.new.tap do |config|
+          config.index.slideshow_field = :xyz 
+          config.track_search_session = false
+        end
+      end
       let(:document) { SolrDocument.new({ xyz: 'http://example.com/some.jpg', id: 'x' }) }
 
       it { is_expected.to have_selector 'img[src="http://example.com/some.jpg"]' }
@@ -74,10 +77,12 @@ RSpec.describe Blacklight::Gallery::SlideshowComponent, type: :component do
     end
 
     context 'falling back to a thumbnail' do
-      let(:blacklight_config) { Blacklight::Configuration.new.tap { |config| 
-        config.index.thumbnail_field = :xyz 
-        config.track_search_session = false
-        } }
+      let(:blacklight_config) do
+        Blacklight::Configuration.new.tap do |config|
+          config.index.thumbnail_field = :xyz 
+          config.track_search_session = false
+        end
+      end
       let(:document) { SolrDocument.new({ xyz: 'http://example.com/thumb.jpg', id: 'x' }) }
 
       it { is_expected.to have_selector 'img[src="http://example.com/thumb.jpg"]' }


### PR DESCRIPTION
Fixes DLME [#1373](https://github.com/sul-dlss/dlme/issues/1373)

It was suggested to solve this issue by making a change in the upstream repo here

Changes made:

- Removes `suppress_link: true` option from the image in the slideshow modal
- Adds link to item heading in slideshow modal to document
- Modifies CSS to cover new `<a>` tags
- Modifies test to ignore search session tracking and handle linking
