### PR TITLE
Don't set flex-basis for gallery documents

### DIFF
--- a/app/assets/stylesheets/blacklight_gallery/_gallery.scss
+++ b/app/assets/stylesheets/blacklight_gallery/_gallery.scss
@@ -2,9 +2,7 @@
   .document {
     border-bottom: none;
     display: flex;
-
     min-height: 250px;
-    -webkit-flex: 1 0 250px;
   }
 
   .caption {


### PR DESCRIPTION
Related to [DLME Issue #1109](https://github.com/sul-dlss/dlme/issues/1109) and [this PR.](https://github.com/sul-dlss/dlme/pull/1507)

This `flex-basis` value of 250px seems to have been added to workaround an [old flex bug](https://github.com/projectblacklight/blacklight-gallery/commit/ba61fd59731b915a19506f0c0ff68f89ce689f54) which is[ now fixed. ](https://bugs.webkit.org/show_bug.cgi?id=136041)

Context: this was uncovered because it was interfering with the intended `row-cols-md-4` behavior from Spotlight. With the previous value set at 250px, a maximum 4 columns fit into the Bootstrap `xl` container at 1200px. Now with an `xxl` container at 1400px in Bootstrap 5, 5 columns were able to fit, which threw off the pagination logic (rows of 5, 5, 2 rather than 4, 4, 4). Setting flex-basis back to auto resolved the issue.

