### PR TITLE
Provide icon components for Blacklight 8 

### DIFF
--- a/app/components/blacklight/gallery/icons/add_circle_component.rb
+++ b/app/components/blacklight/gallery/icons/add_circle_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Gallery
+    module Icons
+      # This is the icon for the add button.
+      # You can override the default svg by setting:
+      #   Blacklight::Gallery:Icons::AddCircleComponent.svg = '<svg>your SVG here</svg>'
+      class AddCircleComponent < Blacklight::Icons::IconComponent
+        self.svg = <<~SVG
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+            <path fill="none" d="M0 0h24v24H0V0z"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"/>
+          </svg>
+        SVG
+      end
+    end
+  end
+end

--- a/app/components/blacklight/gallery/icons/chevron_left_component.rb
+++ b/app/components/blacklight/gallery/icons/chevron_left_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Gallery
+    module Icons
+      # This is the gallery icon for the view type button.
+      # You can override the default svg by setting:
+      #   Blacklight::Gallery:Icons::ChevronLeftComponent.svg = '<svg>your SVG here</svg>'
+      class ChevronLeftComponent < Blacklight::Icons::IconComponent
+        self.svg = <<~SVG
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+            <path fill="none" d="M0 0h24v24H0V0z"/><path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12l4.58-4.59z"/>
+          </svg>
+        SVG
+      end
+    end
+  end
+end

--- a/app/components/blacklight/gallery/icons/chevron_right_component.rb
+++ b/app/components/blacklight/gallery/icons/chevron_right_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Gallery
+    module Icons
+      # This is the gallery icon for the view type button.
+      # You can override the default svg by setting:
+      #   Blacklight::Gallery:Icons::ChevronRightComponent.svg = '<svg>your SVG here</svg>'
+      class ChevronRightComponent < Blacklight::Icons::IconComponent
+        self.svg = <<~SVG
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+            <path fill="none" d="M0 0h24v24H0V0z"/><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6-6-6z"/>
+          </svg>
+        SVG
+      end
+    end
+  end
+end

--- a/app/components/blacklight/gallery/icons/custom_fullscreen_component.rb
+++ b/app/components/blacklight/gallery/icons/custom_fullscreen_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Gallery
+    module Icons
+      # This is the icon for the fullscreen button.
+      # You can override the default svg by setting:
+      #   Blacklight::Gallery:Icons::CustomFullscreenComponent.svg = '<svg>your SVG here</svg>'
+      class CustomFullscreenComponent < Blacklight::Icons::IconComponent
+        self.svg = <<~SVG
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+            <path d="M7,14H5v5h5V17H7Zm7-9V7h3v3h2V5Z" /><path d="M22.517,1.524H1.736V22.37H22.517Zm-2,18.845H3.736V3.524H20.517Z" />
+          </svg>
+        SVG
+      end
+    end
+  end
+end

--- a/app/components/blacklight/gallery/icons/gallery_component.rb
+++ b/app/components/blacklight/gallery/icons/gallery_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Gallery
+    module Icons
+      # This is the gallery icon for the view type button.
+      # You can override the default svg by setting:
+      #   Blacklight::Gallery:Icons::GalleryComponent.svg = '<svg>your SVG here</svg>'
+      class GalleryComponent < Blacklight::Icons::IconComponent
+        self.svg = <<~SVG
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+            <path fill="none" d="M0 0h24v24H0V0z"/><path d="M4 11h5V5H4v6zm0 7h5v-6H4v6zm6 0h5v-6h-5v6zm6 0h5v-6h-5v6zm-6-7h5V5h-5v6zm6-6v6h5V5h-5z"/>
+          </svg>
+        SVG
+      end
+    end
+  end
+end

--- a/app/components/blacklight/gallery/icons/masonry_component.rb
+++ b/app/components/blacklight/gallery/icons/masonry_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Gallery
+    module Icons
+      # This is the gallery icon for the view type button.
+      # You can override the default svg by setting:
+      #   Blacklight::Gallery:Icons::MasonryComponent.svg = '<svg>your SVG here</svg>'
+      class MasonryComponent < Blacklight::Icons::IconComponent
+        self.svg = <<~SVG
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+            <path fill="none" d="M0 0h24v24H0V0z"/><path d="M10 18h5v-6h-5v6zm-6 0h5V5H4v13zm12 0h5v-6h-5v6zM10 5v6h11V5H10z"/>
+          </svg>
+        SVG
+      end
+    end
+  end
+end

--- a/app/components/blacklight/gallery/icons/pause_slideshow_component.rb
+++ b/app/components/blacklight/gallery/icons/pause_slideshow_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Gallery
+    module Icons
+      # This is the gallery icon for the view type button.
+      # You can override the default svg by setting:
+      #   Blacklight::Gallery:Icons::PauseSlideshowComponent.svg = '<svg>your SVG here</svg>'
+      class PauseSlideshowComponent < Blacklight::Icons::IconComponent
+        self.svg = <<~SVG
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 14H9V8h2v8zm4 0h-2V8h2v8z"></path>
+          </svg>
+        SVG
+      end
+    end
+  end
+end

--- a/app/components/blacklight/gallery/icons/remove_circle_component.rb
+++ b/app/components/blacklight/gallery/icons/remove_circle_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Gallery
+    module Icons
+      # This is the icon for the remove button.
+      # You can override the default svg by setting:
+      #   Blacklight::Gallery:Icons::RemoveCircleComponent.svg = '<svg>your SVG here</svg>'
+      class RemoveCircleComponent < Blacklight::Icons::IconComponent
+        self.svg = <<~SVG
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+            <path fill="none" d="M0 0h24v24H0V0z"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11H7v-2h10v2z"/>
+          </svg>
+        SVG
+      end
+    end
+  end
+end

--- a/app/components/blacklight/gallery/icons/resize_small_component.rb
+++ b/app/components/blacklight/gallery/icons/resize_small_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Gallery
+    module Icons
+      # This is the icon for the resize button.
+      # You can override the default svg by setting:
+      #   Blacklight::Gallery:Icons::ResizeSmallComponent.svg = '<svg>your SVG here</svg>'
+      class ResizeSmallComponent < Blacklight::Icons::IconComponent
+        self.svg = <<~SVG
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+            <path d="M5,16H8v3h2V14H5ZM16,8V5H14v5h5V8Z"/><path d="M22.517,1.524H1.736V22.37H22.517Zm-2,18.845H3.736V3.524H20.517Z"/>
+          </svg>
+        SVG
+      end
+    end
+  end
+end

--- a/app/components/blacklight/gallery/icons/slideshow_component.rb
+++ b/app/components/blacklight/gallery/icons/slideshow_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Gallery
+    module Icons
+      # This is the gallery icon for the view type button.
+      # You can override the default svg by setting:
+      #   Blacklight::Gallery:Icons::SlideshowComponent.svg = '<svg>your SVG here</svg>'
+      class SlideshowComponent < Blacklight::Icons::IconComponent
+        self.svg = <<~SVG
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 25 24">
+            <path d="m1 9v6h-1v-6zm6-3h12v13h-13v-13zm11 1h-11v11h11zm-13 0v11h-1v-11zm-2 1v9h-1v-9zm18-1v11h-1v-11zm2 1v8h-1v-8zm2 1v5h-1v-5z"/>
+          </svg>
+        SVG
+      end
+    end
+  end
+end

--- a/app/components/blacklight/gallery/icons/start_slideshow_component.rb
+++ b/app/components/blacklight/gallery/icons/start_slideshow_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Gallery
+    module Icons
+      # This is the gallery icon for the view type button.
+      # You can override the default svg by setting:
+      #   Blacklight::Gallery:Icons::StartSlideshowComponent.svg = '<svg>your SVG here</svg>'
+      class StartSlideshowComponent < Blacklight::Icons::IconComponent
+        self.svg = <<~SVG
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z"></path>
+          </svg>
+        SVG
+      end
+    end
+  end
+end

--- a/app/views/catalog/_document_slideshow.html.erb
+++ b/app/views/catalog/_document_slideshow.html.erb
@@ -15,18 +15,18 @@
 
       <!-- Controls -->
       <a class="left carousel-control prev" href="#slideshow" data-slide="prev">
-        <%= blacklight_icon 'chevron_left', additional_options: { label_context: 'previous_image' } %>
+        <%= render Blacklight::Gallery::Icons::ChevronLeftComponent.new additional_options: { label_context: 'previous_image' } %>
       </a>
       <a class="right carousel-control next" href="#slideshow" data-slide="next">
-        <%= blacklight_icon 'chevron_right', additional_options: { label_context: 'next_image' } %>
+        <%= render Blacklight::Gallery::Icons::ChevronRightComponent.new additional_options: { label_context: 'next_image' } %>
       </a>
 
       <div class="controls text-center">
         <button class="btn btn-sm btn-link" data-behavior="pause-slideshow" aria-label="<%= t('blacklight_gallery.catalog.slideshow.pause') %>">
-          <%= blacklight_icon 'pause_slideshow' %>
+        <%= render Blacklight::Gallery::Icons::PauseSlideshowComponent.new %>
         </button>
         <button class="btn btn-sm btn-link" data-behavior="start-slideshow" aria-label="<%= t('blacklight_gallery.catalog.slideshow.start') %>">
-          <%= blacklight_icon 'start_slideshow' %>
+          <%= render Blacklight::Gallery::Icons::StartSlideshowComponent.new %>
         </button>
       </div>
     </div>

--- a/app/views/catalog/_openseadragon_default.html.erb
+++ b/app/views/catalog/_openseadragon_default.html.erb
@@ -29,16 +29,16 @@
       <div class="col-md-6 pagination">
         <% if count > 1 %>
           <% osd_config = osd_config_referencestrip.merge(osd_config) %>
-            <a id="<%= id_prefix %>-previous"><%= blacklight_icon('chevron_left') %></a>
+            <a id="<%= id_prefix %>-previous"><%= render Blacklight::Gallery::Icons::ChevronLeftComponent.new %></a>
             <span id="<%= id_prefix %>-page">1</span>  of <%= count %>
-            <a id="<%= id_prefix %>-next"><%= blacklight_icon('chevron_right') %></a>
+            <a id="<%= id_prefix %>-next"><%= render Blacklight::Gallery::Icons::ChevronRightComponent.new  %></a>
         <% end %>
       </div>
       <div class="col-md-6 controls">
-        <a id="<%= id_prefix %>-zoom-in"><%= blacklight_icon('add_circle') %></a>
-        <a id="<%= id_prefix %>-zoom-out"><%= blacklight_icon('remove_circle') %></a>
-        <a id="<%= id_prefix %>-home"><%= blacklight_icon('resize_small') %></a>
-        <a id="<%= id_prefix %>-full-page"><%= blacklight_icon('custom_fullscreen') %></a>
+        <a id="<%= id_prefix %>-zoom-in"><%= render Blacklight::Gallery::Icons::AddCircleComponent.new %></a>
+        <a id="<%= id_prefix %>-zoom-out"><%= render Blacklight::Gallery::Icons::RemoveCircleComponent.new %></a>
+        <a id="<%= id_prefix %>-home"><%= render Blacklight::Gallery::Icons::ResizeSmallComponent.new %></a>
+        <a id="<%= id_prefix %>-full-page"><%= render Blacklight::Gallery::Icons::CustomFullscreenComponent.new %></a>
       </div>
     </div>
     <%= openseadragon_picture_tag image, class: 'osd-image row', data: { openseadragon: osd_config } %>

--- a/lib/generators/blacklight_gallery/install_generator.rb
+++ b/lib/generators/blacklight_gallery/install_generator.rb
@@ -7,9 +7,9 @@ module BlacklightGallery
 
     def configuration
       inject_into_file 'app/controllers/catalog_controller.rb', after: "configure_blacklight do |config|" do
-        "\n    config.view.gallery(document_component: Blacklight::Gallery::DocumentComponent)" \
-        "\n    config.view.masonry(document_component: Blacklight::Gallery::DocumentComponent)" \
-        "\n    config.view.slideshow(document_component: Blacklight::Gallery::SlideshowComponent)" \
+        "\n    config.view.gallery(document_component: Blacklight::Gallery::DocumentComponent, icon: Blacklight::Gallery::Icons::GalleryComponent)" \
+        "\n    config.view.masonry(document_component: Blacklight::Gallery::DocumentComponent, icon: Blacklight::Gallery::Icons::MasonryComponent)" \
+        "\n    config.view.slideshow(document_component: Blacklight::Gallery::SlideshowComponent, icon: Blacklight::Gallery::Icons::SlideshowComponent)" \
         "\n    config.show.tile_source_field = :content_metadata_image_iiif_info_ssm" \
         "\n    config.show.partials.insert(1, :openseadragon)"
       end


### PR DESCRIPTION
### Upgrading help:
Specify the icons to use to avoid deprecation warnings:

```ruby
# app/controllers/catalog_controller.rb
config.view.gallery(document_component: Blacklight::Gallery::DocumentComponent, icon: Blacklight::Gallery::Icons::GalleryComponent)
config.view.masonry(document_component: Blacklight::Gallery::DocumentComponent, icon: Blacklight::Gallery::Icons::MasonryComponent)
config.view.slideshow(document_component: Blacklight::Gallery::SlideshowComponent, icon: Blacklight::Gallery::Icons::SlideshowComponent)
```
