### PR TITLE
fix document-title-heading css heirarchy

### DIFF
--- a/app/assets/stylesheets/blacklight_gallery/_gallery.scss
+++ b/app/assets/stylesheets/blacklight_gallery/_gallery.scss
@@ -21,12 +21,12 @@
     clear: left;
   }
 
-  .document-metadata {
-    .document-title-heading {
-      padding-left: 0;
-      padding-right: 0;
-    }
+  .document-title-heading {
+    padding-left: 0;
+    padding-right: 0;
+  }
 
+  .document-metadata {
     dt, dd {
       flex: 0 0 100%;
       max-width: 100%;


### PR DESCRIPTION
document-title-heading is not in document-metadata in Blacklight.
<img width="523" alt="Screenshot 2024-09-09 at 5 49 38 PM" src="https://github.com/user-attachments/assets/4bc59b6e-b931-4671-a2d3-9f0dfc8b8b4f">

https://github.com/projectblacklight/blacklight-gallery/blob/main/app/components/blacklight/gallery/document_component.html.erb#L12-L14

Closes [#2087](https://github.com/sul-dlss/exhibits/issues/2087)