### PR TITLE
Pin SolrWrapper Solr version to 9.6.1

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -3,3 +3,4 @@
 collection:
   dir: solr/conf/
   name: blacklight-core
+version: '9.6.1'


### PR DESCRIPTION
Solr 9.7.0 doesn't work with SolrWrapper yet, so let's pin to Solr 9.6.1 for now so CI will work again.