### PR TITLE
Allow the openseadgragon view to accept more flexible view_config

### DIFF
--- a/app/views/catalog/_openseadragon_default.html.erb
+++ b/app/views/catalog/_openseadragon_default.html.erb
@@ -1,5 +1,6 @@
 <%
-  image = document.to_openseadragon(blacklight_config.view_config(:show))
+  view_config = local_assigns[:view_config] || blacklight_config&.view_config(document_index_view_type)
+  image = document.to_openseadragon(view_config)
   id_prefix = osd_html_id_prefix
 %>
 <%

--- a/spec/views/catalog/_openseadragon_default.html.erb_spec.rb
+++ b/spec/views/catalog/_openseadragon_default.html.erb_spec.rb
@@ -4,10 +4,18 @@ describe "catalog/openseadragon_default" do
   let(:document) { SolrDocument.new }
   let(:blacklight_config) { Blacklight::Configuration.new }
   let(:p) { "catalog/openseadragon_default" }
+  let(:view_config) do
+    Blacklight::Configuration::ViewConfig.new(document_component: Blacklight::Gallery::OpenseadragonSolrDocument)
+  end
 
   before do
-    allow(view).to receive_messages(blacklight_config: blacklight_config, openseadragon_picture_tag: "<img />")
     allow(document).to receive_messages(to_openseadragon: [])
+    allow(view).to receive_messages(
+      blacklight_config: blacklight_config,
+      documents: [document],
+      document_index_view_type: 'embed',
+      openseadragon_picture_tag: '<img />'
+    )
   end
 
   it "should render the openseadragon container" do


### PR DESCRIPTION
This conforms to the pattern of the other catalog views.
Related to https://github.com/projectblacklight/spotlight/issues/3111