### PR TITLE
Openseadragon fixes

### DIFF
--- a/app/components/blacklight/gallery/openseadragon_embed_component.html.erb
+++ b/app/components/blacklight/gallery/openseadragon_embed_component.html.erb
@@ -2,18 +2,18 @@
   <div class="osd-toolbar row">
     <div class="col-md-6 pagination">
       <% if count > 1 %>
-        <% osd_config = osd_config_referencestrip.merge(osd_config) %>
-          <a id="<%= id_prefix %>-previous"><%= render Blacklight::Gallery::Icons::ChevronLeftComponent.new %></a>
-          <span id="<%= id_prefix %>-page">1</span> of <%= count %>
-          <a id="<%= id_prefix %>-next"><%= render Blacklight::Gallery::Icons::ChevronRightComponent.new  %></a>
+        <% multi_page_osd_config = osd_config_referencestrip.merge(osd_config) %>
+        <a id="<%= @id_prefix %>-previous"><%= render Blacklight::Gallery::Icons::ChevronLeftComponent.new %></a>
+        <span id="<%= @id_prefix %>-page">1</span>&nbsp; of <%= count %>
+        <a id="<%= @id_prefix %>-next"><%= render Blacklight::Gallery::Icons::ChevronRightComponent.new  %></a>
       <% end %>
     </div>
     <div class="col-md-6 controls">
-      <a id="<%= id_prefix %>-zoom-in"><%= render Blacklight::Gallery::Icons::AddCircleComponent.new %></a>
-      <a id="<%= id_prefix %>-zoom-out"><%= render Blacklight::Gallery::Icons::RemoveCircleComponent.new %></a>
-      <a id="<%= id_prefix %>-home"><%= render Blacklight::Gallery::Icons::ResizeSmallComponent.new %></a>
-      <a id="<%= id_prefix %>-full-page"><%= render Blacklight::Gallery::Icons::CustomFullscreenComponent.new %></a>
+      <a id="<%= @id_prefix %>-zoom-in"><%= render Blacklight::Gallery::Icons::AddCircleComponent.new %></a>
+      <a id="<%= @id_prefix %>-zoom-out"><%= render Blacklight::Gallery::Icons::RemoveCircleComponent.new %></a>
+      <a id="<%= @id_prefix %>-home"><%= render Blacklight::Gallery::Icons::ResizeSmallComponent.new %></a>
+      <a id="<%= @id_prefix %>-full-page"><%= render Blacklight::Gallery::Icons::CustomFullscreenComponent.new %></a>
     </div>
   </div>
-  <%= helpers.openseadragon_picture_tag image, class: 'osd-image row', data: { openseadragon: osd_config } %>
+  <%= helpers.openseadragon_picture_tag image, class: 'osd-image row', data: { openseadragon: multi_page_osd_config ? multi_page_osd_config : osd_config } %>
 </div>

--- a/app/components/blacklight/gallery/openseadragon_embed_component.rb
+++ b/app/components/blacklight/gallery/openseadragon_embed_component.rb
@@ -12,6 +12,7 @@ module Blacklight
         @presenter = presenter
         @view_config = view_config
         @classes = classes
+        @id_prefix = id_prefix
       end
 
       def image
@@ -33,12 +34,12 @@ module Blacklight
       def osd_config
         {
           crossOriginPolicy: false,
-          zoomInButton: "#{id_prefix}-zoom-in",
-          zoomOutButton: "#{id_prefix}-zoom-out",
-          homeButton: "#{id_prefix}-home",
-          fullPageButton: "#{id_prefix}-full-page",
-          nextButton: "#{id_prefix}-next",
-          previousButton: "#{id_prefix}-previous"
+          zoomInButton: "#{@id_prefix}-zoom-in",
+          zoomOutButton: "#{@id_prefix}-zoom-out",
+          homeButton: "#{@id_prefix}-home",
+          fullPageButton: "#{@id_prefix}-full-page",
+          nextButton: "#{@id_prefix}-next",
+          previousButton: "#{@id_prefix}-previous"
         }
       end
 

--- a/app/components/blacklight/gallery/openseadragon_embed_component.rb
+++ b/app/components/blacklight/gallery/openseadragon_embed_component.rb
@@ -46,9 +46,8 @@ module Blacklight
       def osd_config_referencestrip
         {
           showReferenceStrip: true,
-          referenceStripPosition: 'OUTSIDE',
+          sequenceMode: true,
           referenceStripScroll: 'vertical',
-          referenceStripWidth: 100,
           referenceStripBackgroundColor: 'transparent'
         }
       end

--- a/spec/components/blacklight/gallery/openseadragon_embed_component_spec.rb
+++ b/spec/components/blacklight/gallery/openseadragon_embed_component_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Blacklight::Gallery::OpenseadragonEmbedComponent, type: :component do
+  subject(:component) do
+    described_class.new(
+      document: document,
+      presenter: presenter,
+      **attr
+    )
+  end
+
+  let(:attr) { {} }
+  let(:view_context) { vc_test_controller.view_context }
+  let(:render) do
+    component.render_in(view_context)
+  end
+
+  let(:rendered) do
+    Capybara::Node::Simple.new(render)
+  end
+
+  let(:document) do
+    SolrDocument.new(
+      id: 'x'
+    )
+  end
+
+  let(:presenter) { Blacklight::IndexPresenter.new(document, view_context, blacklight_config) }
+
+  before do
+    allow(view_context).to receive(:current_search_session).and_return(nil)
+    allow(view_context).to receive(:search_session).and_return({})
+    allow(view_context).to receive(:blacklight_config).and_return(blacklight_config)
+  end
+
+  describe 'openseadragon viewer' do
+    let(:blacklight_config) do
+      Blacklight::Configuration.new.tap do |config|
+        config.index.slideshow_method = :xyz
+        if Blacklight::VERSION > '8'
+          config.track_search_session.storage = false
+        else
+          config.track_search_session = false
+        end
+      end
+    end
+    it 'uses a single @id_prefix to generate unique control ids' do
+      expect(component.osd_config[:zoomInButton]).to include(component.instance_variable_get(:@id_prefix))
+      expect(component.osd_config[:zoomOutButton]).to include(component.instance_variable_get(:@id_prefix))
+      expect(component.osd_config[:homeButton]).to include(component.instance_variable_get(:@id_prefix))
+      expect(component.osd_config[:fullPageButton]).to include(component.instance_variable_get(:@id_prefix))
+      expect(component.osd_config[:nextButton]).to include(component.instance_variable_get(:@id_prefix))
+      expect(component.osd_config[:previousButton]).to include(component.instance_variable_get(:@id_prefix))
+    end
+  end
+end


### PR DESCRIPTION
Closes [#3178](https://github.com/projectblacklight/spotlight/issues/3178)
This was tested as part of a Spotlight application.

Changes:
1. the custom icons had stopped working because the ViewComponent was generating sequential ids (so `1-zoom-in` `2-zoom-out`) rather than using a consistent id for all control elements.

~~2. I wasn't able to get tests to pass without changes to the `@presenter` setup, which mimics the setup in the other ViewComponents.~~

2. In testing this work I found that multi-page items were rendering incorrectly. It seems that the options/params expected by OSD have changed: I needed to add `sequenceMode: true`, and I was able to remove other options that were set by default. Before (goes to last page and is just broken):
<img width="723" alt="Screenshot 2024-10-09 at 3 45 02 PM" src="https://github.com/user-attachments/assets/405cfb2d-c8d3-4968-a6d5-27029d31d655">

After:
<img width="775" alt="Screenshot 2024-10-09 at 3 45 21 PM" src="https://github.com/user-attachments/assets/29341942-c7bd-4c6c-9683-b99e74cd5faf">


