### PR TITLE
Export the module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.8.3",
   "description": "Gallery views for Blacklight search results",
   "exports": {
+    "./blacklight-gallery.esm.js": "./app/assets/javascripts/blacklight_gallery/blacklight-gallery.esm.js",
     ".": "./app/javascript/blacklight-gallery/index.js",
     "./*": "./app/javascript/blacklight-gallery/*.js"
   },


### PR DESCRIPTION
I think this makes it easier to get the rolled-up module when using tools like the node resolve rollup plugin that uses the config from `exports`.