### PR TITLE
Use bundler.with_unbundled_env

### DIFF
--- a/lib/generators/blacklight_gallery/install_generator.rb
+++ b/lib/generators/blacklight_gallery/install_generator.rb
@@ -24,7 +24,7 @@ module BlacklightGallery
 
     def add_openseadragon
       gem "openseadragon", "~> 1.0"
-      Bundler.with_clean_env { run 'bundle install' }
+      Bundler.with_unbundled_env { run 'bundle install' }
       generate 'openseadragon:install'
     end
 

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -8,7 +8,7 @@ class TestAppGenerator < Rails::Generators::Base
   def run_blacklight_generator
     say_status("warning", "GENERATING BL", :yellow)       
 
-    Bundler.with_clean_env do
+    Bundler.with_unbundled_env do
       run "bundle install"
     end
 


### PR DESCRIPTION
`Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`.