### PR TITLE
Removing support for Rails 5 and 6.0 in Gemfile 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,16 +32,6 @@ else
     else
       gem 'rails', ENV['RAILS_VERSION']
     end
-
-    case ENV['RAILS_VERSION']
-    when /^6.0/
-      gem 'sass-rails', '>= 6'
-      gem 'webpacker', '~> 4.0'
-    when /^5.[12]/
-      gem 'sass-rails', '~> 5.0'
-      gem 'sprockets', '~> 3.7'
-      gem 'thor', '~> 0.20'
-    end
   end
 end
 # END ENGINE_CART BLOCK


### PR DESCRIPTION
`blacklight-gallery` only supports rails 6.1+