### PR TITLE
Updates to README to improve installation and usage guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Blacklight::Gallery
 [![Gem Version](https://badge.fury.io/rb/blacklight-gallery.svg)](http://badge.fury.io/rb/blacklight-gallery) [![CI](https://github.com/projectblacklight/blacklight-gallery/actions/workflows/ruby.yml/badge.svg)](https://github.com/projectblacklight/blacklight-gallery/actions/workflows/ruby.yml)
 
-Gallery views for Blacklight search results
+Image-centric "Gallery" views for Blacklight search results.
 
 ## Installation
 
@@ -19,31 +19,48 @@ Or install it yourself as:
 
 ## Usage
 
-Run the gallery generator for Sprockets:
+### With Sprockets
 
-    $ rails g blacklight_gallery:install
+If your asset pipeline uses Sprockets, simply run the gallery generator:
 
-Or for node based bundlers add `blacklight-gallery masonry-layout@v4` as a dependencies and add this to your entrypoint:
+```sh
+$ rails g blacklight_gallery:install
+```
+
+### With Importmaps
+
+New installations of Blacklight will probably use [Importmaps](https://github.com/rails/importmap-rails) to manage javascript assets. In order to support the masonry and slideshow views, jQuery needs to be added to your application Importmaps configuration.
+
+In addition to running the `blacklight_gallery:install` generator, add this line to `/config/importmap.rb`:
+
+```ruby
+pin "jquery", to: "https://code.jquery.com/jquery-3.7.1.min.js"
+```
+
+Then append import declarations in your `app/assets/javascript/application.js`:
+
+```js
+import 'jquery'
+import 'blacklight-gallery'
+```
+
+### With Node-based JS bundlers
+
+For node-based bundlers add `blacklight-gallery masonry-layout@v4` as a dependency and add this to your entrypoint:
 ```js
 import 'blacklight-gallery/vendor/assets/javascripts/imagesloaded.pkgd.js'
 import 'blacklight-gallery/app/javascript/blacklight-gallery/slideshow'
 import 'blacklight-gallery/app/javascript/blacklight-gallery/masonry'
 ```
 
-## Available Views
-If you would like to add or remove any particular view either add or remove the following configurations from your Blacklight controller.
+### With Propshaft
 
-### Gallery
+Propshaft will process and include any CSS files in your `app/assets/stylesheets` directory. The `blacklight_gallery:install` generator adds [a file](https://github.com/projectblacklight/blacklight-gallery/blob/v4.8.4/lib/generators/blacklight_gallery/templates/blacklight_gallery.css.scss) to `app/assets/stylesheets` that loads the included styles for all views.
+The styles require compilation from SASS to CSS, which will require usage of a compiler like [`dartsass-rails`](https://github.com/rails/dartsass-rails).
 
-    config.view.gallery.partials = [:index_header, :index]
+## Manual Installation
 
-### Masonry
-
-    config.view.masonry.partials = [:index]
-
-### Slideshow
-
-    config.view.slideshow.partials = [:index]
+See the wiki page on [manual installation](https://github.com/projectblacklight/blacklight-gallery/wiki/Manual-Installation) to customize which views and related assets to install into your application.
 
 ## Screenshot
 
@@ -60,7 +77,7 @@ If you would like to add or remove any particular view either add or remove the 
 ## Releasing
 
 1. Edit `lib/version.rb` and `package.json` to set the new version
-1. Commit the changes e.g. `git commit -am "Bump version to X.X.X"`
-1. Push release to rubygems `bundle exec rake release`
-1. Push release to NPM `npm publish`
-1. Create a release on github with the tag that was just created: https://github.com/projectblacklight/blacklight-gallery/releases/new
+2. Commit the changes e.g. `git commit -am "Bump version to X.X.X"`
+3. Push release to rubygems `bundle exec rake release`
+4. Push release to NPM `npm publish`
+5. Create a release on github with the tag that was just created: https://github.com/projectblacklight/blacklight-gallery/releases/new


### PR DESCRIPTION
Adds additional "Usage" guidance to README to address issues when working with the `4.x` versions.

- attempt to address installation with different asset management choices
- link out to new "manual installation" wiki page for including/excluding specific views

Closes #183 and #180 