### PR TITLE
Convert OSD Viewer SCSS to CSS

### DIFF
--- a/app/assets/stylesheets/blacklight_gallery/_osd_viewer.css
+++ b/app/assets/stylesheets/blacklight_gallery/_osd_viewer.css
@@ -21,7 +21,7 @@
   }
 
   .osd-image {
-    border: 1px solid var(--bs-gray-300);
+    border: 1px solid var(--bs-gray-400);
     height: 400px;
   }
 }

--- a/app/assets/stylesheets/blacklight_gallery/_osd_viewer.css
+++ b/app/assets/stylesheets/blacklight_gallery/_osd_viewer.css
@@ -1,5 +1,4 @@
 .openseadragon-container {
-
   .osd-toolbar {
     padding: 5px 0;
 
@@ -22,8 +21,7 @@
   }
 
   .osd-image {
-    border: 1px solid #ccc;
+    border: 1px solid var(--bs-gray-300);
     height: 400px;
-
   }
 }


### PR DESCRIPTION
This is a very simple conversion, but the documentation on setting up the internal test app for OSD on the show page is nonexistent - we need to find a way to configure a simple OSD setup for testing purposes.

- [x] Test on BL8
- [x] Test on BL9