### PR TITLE
Add generator step to uncomment thumbnail config

### DIFF
--- a/lib/generators/blacklight_gallery/install_generator.rb
+++ b/lib/generators/blacklight_gallery/install_generator.rb
@@ -39,5 +39,12 @@ module BlacklightGallery
         "\n//= require blacklight_gallery/blacklight-gallery"
       end
     end
+
+    def uncomment_thumbnail_config
+      gsub_file('app/controllers/catalog_controller.rb',
+                /# config\.index\.thumbnail_field = 'thumbnail_path_ss'/) do |match|
+        match.gsub(/# /, '')
+      end
+    end
   end
 end


### PR DESCRIPTION
We'd like thumbnails to show up in development, so this adds a generator step to uncomment the catalog controller configuration that does that.