### PR TITLE
Fix slideshow modal header close

### DIFF
--- a/app/assets/stylesheets/blacklight_gallery/slideshow.css
+++ b/app/assets/stylesheets/blacklight_gallery/slideshow.css
@@ -10,11 +10,6 @@
     .modal-header {
       border-bottom: none;
       padding: 0.5rem 1rem;
-
-      .close {
-        font-size: 2.5rem;
-        color: white;
-      }
     }
 
     .modal-body {
@@ -79,7 +74,6 @@
   .carousel-control.right {
     right: 0px;
   }
-
   .caption {
     font-size: 1rem;
     margin: 10px auto;

--- a/app/views/catalog/_slideshow_modal.html.erb
+++ b/app/views/catalog/_slideshow_modal.html.erb
@@ -4,7 +4,6 @@
       <div class="modal-content">
         <div class="modal-header">
           <button type="button" class="blacklight-modal-close btn-close close btn-close-white" data-dismiss="modal" data-bs-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
-            <span aria-hidden="true" class="visually-hidden">&times;</span>
           </button>
         </div>
         <div class="modal-body">


### PR DESCRIPTION
It was way too big. The color: white does nothing.  The inner span is not necessary